### PR TITLE
feat: 편집된 할일 데이터베이스 업데이트

### DIFF
--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 
-import { findAllTodos, createTodo, deleteTodo } from '@/services/todo';
+import { findAllTodos, createTodo, deleteTodo, updateTodo } from '@/services/todo';
 
 export const getAllTodosHandler = async (req: Request, res: Response) => {
   try {
@@ -30,5 +30,17 @@ export const deleteTodoHandler = async (req: Request, res: Response) => {
     else throw 'Todo not found';
   } catch (error) {
     res.status(404).json({ message: error });
+  }
+};
+
+export const updateTodoHandler = async (req: Request, res: Response) => {
+  try {
+    const { todoId, newTitle } = req.body;
+    const result = await updateTodo(todoId, newTitle);
+
+    if (result) return res.status(200).json({ message: 'update complete' });
+    else throw 'Todo was not updated';
+  } catch (error) {
+    res.status(400).json({ message: error });
   }
 };

--- a/src/routes/todo.ts
+++ b/src/routes/todo.ts
@@ -1,11 +1,12 @@
 import express from 'express';
 
-import { getAllTodosHandler, createTodoHandler, deleteTodoHandler } from '@/controllers/todo';
+import { getAllTodosHandler, createTodoHandler, deleteTodoHandler, updateTodoHandler } from '@/controllers/todo';
 
 const todoRouter = express.Router();
 
 todoRouter.get('/all', getAllTodosHandler);
 todoRouter.post('/create', createTodoHandler);
 todoRouter.delete('/', deleteTodoHandler);
+todoRouter.patch('/', updateTodoHandler);
 
 export default todoRouter;

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -11,13 +11,8 @@ export const createTodo = async (todo: any) => {
 };
 
 export const deleteTodo = async (todoId: any) => {
-  console.log(todoId);
-  try {
-    const result = await Todo.findOneAndDelete({
-      _id: todoId,
-    });
-    return result;
-  } catch (error: any) {
-    console.log(error.message);
-  }
+  const result = await Todo.findOneAndDelete({
+    _id: todoId,
+  });
+  return result;
 };

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -16,3 +16,15 @@ export const deleteTodo = async (todoId: any) => {
   });
   return result;
 };
+
+export const updateTodo = async (todoId: any, newTitle: any) => {
+  const result = await Todo.findByIdAndUpdate(
+    {
+      _id: todoId,
+    },
+    {
+      title: newTitle,
+    },
+  );
+  return result;
+};


### PR DESCRIPTION
### 개요 (MOZI-80)

- 할 일을 편집하는 기능

### 작업 사항

- updateTodo service
- updateTodo controller
- updateTodo router connection

### 변경후
![image](https://user-images.githubusercontent.com/44183313/179679226-66716a30-8f10-4078-a988-78c1c327bfd4.png)


### 기타
- https patch로 구현했습니다.
- service/todo에서 예외 처리하는 부분을 삭제하고 controller에서 모든 예외를 받도록 변경했습니다.
- service/todo에서 예외가 발생한 경우(예를 들어, 지금은 any로 다루고 있는 todoId가 objectId로 형변환이 불가능한 이상한 값이 올 경우) 몽구스에서 예외를 발생시키고 해당 예외를 controller/todo에서 잡습니다.
- 존재하지 않는 id를 업데이트 요청하는 경우 Todo.findByIdAndUpdate(...)함수의 반환값은 null입니다. 이 때, controller/todo에서 예외를 발생시킵니다(Todo was not updated).
