### PR TITLE
feat: Restful한 api 설정

### DIFF
--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -21,15 +21,15 @@ export const createTodoHandler = async (req: Request, res: Response) => {
 };
 
 export const deleteTodoHandler = async (req: Request, res: Response) => {
-  const result = await deleteTodo(req.query['todoId']);
+  const result = await deleteTodo(req.query['id']);
 
   if (result) res.status(200).json({ message: 'remove complete' });
   else throw 'Todo not found';
 };
 
 export const updateTodoHandler = async (req: Request, res: Response) => {
-  const { todoId, newTitle } = req.body;
-  const result = await updateTodo(todoId, newTitle);
+  const { id, title } = req.body;
+  const result = await updateTodo(id, title);
 
   if (result) res.status(201).json({ message: 'update complete' });
   else throw 'Todo was not updated';

--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -31,6 +31,6 @@ export const updateTodoHandler = async (req: Request, res: Response) => {
   const { todoId, newTitle } = req.body;
   const result = await updateTodo(todoId, newTitle);
 
-  if (result) res.status(200).json({ message: 'update complete' });
+  if (result) res.status(201).json({ message: 'update complete' });
   else throw 'Todo was not updated';
 };

--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -17,7 +17,7 @@ export const getTodosHandler = async (req: Request, res: Response) => {
 export const createTodoHandler = async (req: Request, res: Response) => {
   const todo = await createTodo(req.body);
 
-  res.status(200).json(todo);
+  res.status(201).json(todo);
 };
 
 export const deleteTodoHandler = async (req: Request, res: Response) => {

--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -21,7 +21,7 @@ export const createTodoHandler = async (req: Request, res: Response) => {
 };
 
 export const deleteTodoHandler = async (req: Request, res: Response) => {
-  const result = await deleteTodo(req.query['id']);
+  const result = await deleteTodo(req.params.id);
 
   if (result) res.status(200).json({ message: 'remove complete' });
   else throw 'Todo not found';

--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 
-import { findAllTodos, createTodo, deleteTodo, updateTodo, findTodos } from '@/services/todo';
+import { findAllTodos, createTodo, deleteTodo, updateTodo, findTodo } from '@/services/todo';
 
 export const getAllTodosHandler = async (req: Request, res: Response) => {
   const todos = await findAllTodos();
@@ -8,8 +8,8 @@ export const getAllTodosHandler = async (req: Request, res: Response) => {
   res.status(200).json(todos);
 };
 
-export const getTodosHandler = async (req: Request, res: Response) => {
-  const todos = await findTodos(req.params.id);
+export const getTodoHandler = async (req: Request, res: Response) => {
+  const todos = await findTodo(req.params.id);
 
   res.status(200).json(todos);
 };

--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -1,9 +1,15 @@
 import { Request, Response } from 'express';
 
-import { findAllTodos, createTodo, deleteTodo, updateTodo } from '@/services/todo';
+import { findAllTodos, createTodo, deleteTodo, updateTodo, findTodos } from '@/services/todo';
 
 export const getAllTodosHandler = async (req: Request, res: Response) => {
   const todos = await findAllTodos();
+
+  res.status(200).json(todos);
+};
+
+export const getTodosHandler = async (req: Request, res: Response) => {
+  const todos = await findTodos(req.params.id);
 
   res.status(200).json(todos);
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,7 +7,7 @@ import projectRouter from '@/routes/project';
 
 const routes = express.Router();
 
-routes.use('/todo', todoRouter);
+routes.use('/todos', todoRouter);
 routes.use('/area', areaRouter);
 routes.use('/header', headerRouter);
 routes.use('/project', projectRouter);

--- a/src/routes/todo.ts
+++ b/src/routes/todo.ts
@@ -5,13 +5,13 @@ import {
   createTodoHandler,
   deleteTodoHandler,
   updateTodoHandler,
-  getTodosHandler,
+  getTodoHandler,
 } from '@/controllers/todo';
 
 const todoRouter = express.Router();
 
 todoRouter.get('/', getAllTodosHandler);
-todoRouter.get('/:id', getTodosHandler);
+todoRouter.get('/:id', getTodoHandler);
 todoRouter.post('/', createTodoHandler);
 todoRouter.delete('/', deleteTodoHandler);
 todoRouter.patch('/', updateTodoHandler);

--- a/src/routes/todo.ts
+++ b/src/routes/todo.ts
@@ -13,7 +13,7 @@ const todoRouter = express.Router();
 todoRouter.get('/', getAllTodosHandler);
 todoRouter.get('/:id', getTodoHandler);
 todoRouter.post('/', createTodoHandler);
-todoRouter.delete('/', deleteTodoHandler);
+todoRouter.delete('/:id', deleteTodoHandler);
 todoRouter.patch('/', updateTodoHandler);
 
 export default todoRouter;

--- a/src/routes/todo.ts
+++ b/src/routes/todo.ts
@@ -1,10 +1,17 @@
 import express from 'express';
 
-import { getAllTodosHandler, createTodoHandler, deleteTodoHandler, updateTodoHandler } from '@/controllers/todo';
+import {
+  getAllTodosHandler,
+  createTodoHandler,
+  deleteTodoHandler,
+  updateTodoHandler,
+  getTodosHandler,
+} from '@/controllers/todo';
 
 const todoRouter = express.Router();
 
-todoRouter.get('/all', getAllTodosHandler);
+todoRouter.get('/', getAllTodosHandler);
+todoRouter.get('/:id', getTodosHandler);
 todoRouter.post('/create', createTodoHandler);
 todoRouter.delete('/', deleteTodoHandler);
 todoRouter.patch('/', updateTodoHandler);

--- a/src/routes/todo.ts
+++ b/src/routes/todo.ts
@@ -12,7 +12,7 @@ const todoRouter = express.Router();
 
 todoRouter.get('/', getAllTodosHandler);
 todoRouter.get('/:id', getTodosHandler);
-todoRouter.post('/create', createTodoHandler);
+todoRouter.post('/', createTodoHandler);
 todoRouter.delete('/', deleteTodoHandler);
 todoRouter.patch('/', updateTodoHandler);
 

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -5,9 +5,9 @@ export const findAllTodos = async () => {
   return todos;
 };
 
-export const findTodo = async (todoId: any) => {
+export const findTodo = async (id: any) => {
   const todo = await Todo.findOne({
-    _id: todoId,
+    _id: id,
   });
   return todo;
 };
@@ -17,20 +17,20 @@ export const createTodo = async (todo: any) => {
   return newTodo;
 };
 
-export const deleteTodo = async (todoId: any) => {
+export const deleteTodo = async (id: any) => {
   const result = await Todo.findOneAndDelete({
-    _id: todoId,
+    _id: id,
   });
   return result;
 };
 
-export const updateTodo = async (todoId: any, newTitle: any) => {
+export const updateTodo = async (id: any, title: any) => {
   const result = await Todo.findByIdAndUpdate(
     {
-      _id: todoId,
+      _id: id,
     },
     {
-      title: newTitle,
+      title,
     },
   );
   return result;

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -5,11 +5,11 @@ export const findAllTodos = async () => {
   return todos;
 };
 
-export const findTodos = async (todoId: any) => {
-  const todos = await Todo.find({
+export const findTodo = async (todoId: any) => {
+  const todo = await Todo.findOne({
     _id: todoId,
   });
-  return todos;
+  return todo;
 };
 
 export const createTodo = async (todo: any) => {

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -5,6 +5,13 @@ export const findAllTodos = async () => {
   return todos;
 };
 
+export const findTodos = async (todoId: any) => {
+  const todos = await Todo.find({
+    _id: todoId,
+  });
+  return todos;
+};
+
 export const createTodo = async (todo: any) => {
   const newTodo = await Todo.create(todo);
   return newTodo;


### PR DESCRIPTION
### 개요 (MOZI-112)

- 안수찬 멘토님의 Restful한 api 설정 피드백을 기반으로 api 구조 변경

### 작업 사항

- getTodos 기능을 GET 요청의 query string 대신에 path variable로 구현
  ex) api/v1/todos?id=3f3e4a... -> api/v1/todos/3f3e4a
- GET, POST 요청의 status code로 200 대신에 201을 사용
- getTodos api 요청 주소를 api/v1/todo -> api/v1/todos로 변경

### 변경후

![image](https://user-images.githubusercontent.com/44183313/180149015-bee45cb2-762b-444c-ae92-534ff0fd70e5.png)

### 기타

- service 함수(findTodo, deleteTodo...) 에서 인자 이름을 todoId로 받고 있는데 이를 id로 바꾸는 것이 나을까요?