### PR TITLE
feat: PATCH todos/:id 엔드 포인트 변경

### DIFF
--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -28,8 +28,7 @@ export const deleteTodoHandler = async (req: Request, res: Response) => {
 };
 
 export const updateTodoHandler = async (req: Request, res: Response) => {
-  const { id, title } = req.body;
-  const result = await updateTodo(id, title);
+  const result = await updateTodo(req.params.id, req.body);
 
   if (result) res.status(201).json({ message: 'update complete' });
   else throw 'Todo was not updated';

--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -23,13 +23,13 @@ export const createTodoHandler = async (req: Request, res: Response) => {
 export const deleteTodoHandler = async (req: Request, res: Response) => {
   const result = await deleteTodo(req.params.id);
 
-  if (result) res.status(200).json({ message: 'remove complete' });
-  else throw 'Todo not found';
+  if (result) res.status(200).send();
+  else throw 'Todo was not found';
 };
 
 export const updateTodoHandler = async (req: Request, res: Response) => {
   const result = await updateTodo(req.params.id, req.body);
 
-  if (result) res.status(201).json({ message: 'update complete' });
+  if (result) res.status(201).send();
   else throw 'Todo was not updated';
 };

--- a/src/routes/todo.ts
+++ b/src/routes/todo.ts
@@ -14,6 +14,6 @@ todoRouter.get('/', getAllTodosHandler);
 todoRouter.get('/:id', getTodoHandler);
 todoRouter.post('/', createTodoHandler);
 todoRouter.delete('/:id', deleteTodoHandler);
-todoRouter.patch('/', updateTodoHandler);
+todoRouter.patch('/:id', updateTodoHandler);
 
 export default todoRouter;

--- a/src/routes/todo.ts
+++ b/src/routes/todo.ts
@@ -8,12 +8,14 @@ import {
   getTodoHandler,
 } from '@/controllers/todo';
 
+import asyncHandler from '@/utils/asyncHandler';
+
 const todoRouter = express.Router();
 
-todoRouter.get('/', getAllTodosHandler);
-todoRouter.get('/:id', getTodoHandler);
-todoRouter.post('/', createTodoHandler);
-todoRouter.delete('/:id', deleteTodoHandler);
-todoRouter.patch('/:id', updateTodoHandler);
+todoRouter.get('/', asyncHandler(getAllTodosHandler));
+todoRouter.get('/:id', asyncHandler(getTodoHandler));
+todoRouter.post('/', asyncHandler(createTodoHandler));
+todoRouter.delete('/:id', asyncHandler(deleteTodoHandler));
+todoRouter.patch('/:id', asyncHandler(updateTodoHandler));
 
 export default todoRouter;

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -24,13 +24,13 @@ export const deleteTodo = async (id: any) => {
   return result;
 };
 
-export const updateTodo = async (id: any, title: any) => {
+export const updateTodo = async (id: any, todo: any) => {
   const result = await Todo.findByIdAndUpdate(
     {
       _id: id,
     },
     {
-      title,
+      title: todo.title,
     },
   );
   return result;


### PR DESCRIPTION
### 개요 (MOZI-126)

### 작업 사항

남상수 멘토님의 지난 멘토링 API 피드백 바탕으로 리팩토링

- todos API에서 DELETE, UPDATE 요청은 status code 외의 Response는 필요 없음.

- todos API에서 PATCH또한 나머지 요청들 처럼 wildcard를 이용해서 PATCH todos/:id 로 엔드 포인트를 변경

- asyncHandler를 통해서 routes/todo에서 한 번 감싸서 라우터에 등록하기

### 변경후

![image](https://user-images.githubusercontent.com/44183313/181724101-5585a6e2-df79-4e22-a5a2-3d71578dd9a1.png)
존재하지 않는 todo를 접근한 경우

![image](https://user-images.githubusercontent.com/44183313/181724173-999a688e-ca72-465e-8451-82c15043e1d6.png)
삭제나 업데이트에 성공한 경우 아무것도 반환하지 않습니다

### 기타
service/todo/updateTodo 메소드의 구현이 조금 달라졌습니다.
기존에는 id와 title을 인자로 하고 id로 찾은 todo의 title을 바꿔줬는데
이번에는 todo자체를 인자로 받고 todo.title을 그대로 업데이트 시킵니다
```typescript
export const updateTodo = async (id: any, todo: any) => {
  const result = await Todo.findByIdAndUpdate(
    {
      _id: id,
    },
    {
      title: todo.title,
    },
  );
  return result;
};
```