### PR TITLE
feat: todo schema에 location field 추가

### DIFF
--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -4,6 +4,15 @@ const todoSchema = new mongoose.Schema({
   title: {
     type: String,
   },
+  location: {
+    type: {
+      type: String,
+      enum: ['Point'],
+    },
+    coordinates: {
+      type: [Number],
+    },
+  },
   createdAt: {
     type: Date,
     default: Date.now,

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -13,6 +13,11 @@ export const findTodo = async (id: any) => {
 };
 
 export const createTodo = async (todo: any) => {
+  const { longitude, latitude } = todo;
+  todo.location = {
+    type: 'Point',
+    coordinates: [longitude, latitude],
+  };
   const newTodo = await Todo.create(todo);
   return newTodo;
 };


### PR DESCRIPTION
### 개요 (MOZI-116)


### 작업 사항

- todo schema에 location field 추가
- createTodo에서 location field 저장하는 기능 구현

### 변경후
![image](https://user-images.githubusercontent.com/44183313/182017379-1da5b9e9-bc36-485f-a569-0413c53b35db.png)

### 기타

- todo의 location field의 coordinates는 반드시 **경도, 위도**(경위도) 순으로 입력해야합니다.
- 위치 정보를 전달하지 않고 todo 생성 요청하면 null이 채워집니다
- 실제로 존재할 수 없는 경위도여도 mongoDB에서 오류를 던지지 않습니다 (예를 들면, 경도 -240, 위도 99)
- 업데이트 함수를 맞춰서 구현해야하는데 고민입니다.
```typescript
export const updateTodo = async (id: any, title: any) => {
  const result = await Todo.findByIdAndUpdate(
    {
      _id: id,
    },
    {
      title,
    },
  );
  return result;
};
```
