### PR TITLE
chore: ESLint가 src 디렉토리만 검사하도록 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ts-node -r tsconfig-paths/register build/index.js",
     "dev": "nodemon --exec ts-node -r tsconfig-paths/register ./src/index.ts",
     "test": "jest --passWithNoTests",
-    "lint": "eslint --fix .",
+    "lint": "eslint --fix src",
     "prepare": "husky install",
     "build": "tsc -p tsconfig.json"
   },


### PR DESCRIPTION
로컬 환경에서 종종 build 디렉토리를 검사하여 수정한 부분을 에러라고
표시. 이를 방지하고자 타겟 디렉토리 설정.
