### PR TITLE
feat: 장소 검색시 가장 가까운 위치부터 결과를 확인할 수 있는 기능

### DIFF
--- a/src/controllers/location.ts
+++ b/src/controllers/location.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+
+import { getNearby } from '@/services/location';
+
+export const getNearbyHandler = async (req: Request, res: Response) => {
+  const { longitude, latitude, keyword } = req.body;
+  console.log(longitude, latitude, keyword);
+  const locations = await getNearby(longitude, latitude, keyword);
+
+  res.status(200).json(locations);
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,11 +3,13 @@ import express from 'express';
 import todoRouter from '@/routes/todo';
 import webpushRouter from '@/routes/webpush';
 import authRouter from '@/routes/auth';
+import locationRouter from './location';
 
 const routes = express.Router();
 
 routes.use('/todos', todoRouter);
 routes.use('/webpush', webpushRouter);
 routes.use('/auth', authRouter);
+routes.use('/location', locationRouter);
 
 export default routes;

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+import { getNearbyHandler } from '@/controllers/location';
+
+const locationRouter = express.Router();
+
+locationRouter.post('/nearby', getNearbyHandler);
+
+export default locationRouter;

--- a/src/services/location.ts
+++ b/src/services/location.ts
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const googleNearBySearchApiUrl = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json';
+
+const request = async (longitude: number, latitude: number, keyword: string) => {
+  // geoJSON 형식과는 다르게 (latitude, longitude) 순서임
+  const location = `${latitude},${longitude}`;
+  const rankby = 'distance';
+  const language = 'ko';
+  const key = process.env.GOOGLE_NEARBYSEARCH_API_KEY;
+
+  const {
+    data: { results },
+  } = await axios.get(googleNearBySearchApiUrl, {
+    params: {
+      location,
+      keyword,
+      rankby,
+      language,
+      key,
+    },
+  });
+
+  return results;
+};
+
+type location = {
+  name: string;
+  location: [number];
+};
+
+export const getNearby = async (longitude: number, latitude: number, keyword: string) => {
+  const results = await request(longitude, latitude, keyword);
+  const locations: location[] = results.map((result: any) => {
+    const {
+      name,
+      geometry: {
+        location: { lng: longitude, lat: latitude },
+      },
+    } = result;
+    return {
+      name,
+      location: [longitude, latitude],
+    };
+  });
+  return locations;
+};


### PR DESCRIPTION
### 개요 (MOZI-199)

기존의 naver location api에서는 [longitude, latitude] 좌표가 주어졌을 때, 행정 구역상의 위치를 알아내는 것이 최대였습니다. 그러나 google location api의 Nearby Search를 사용하면 구글 지도에 저장된 정보와 검색을 하는 사용자의 위치를 바탕으로 가장 가까운 결과부터 검색 결과를 확인할 수 있습니다.

[Nearby Search Google Developers](https://developers.google.com/maps/documentation/places/web-service/search-nearby#maps_http_places_nearbysearch-js) google api중에서 Nearby Search 라는 api를 사용해서 기능을 구현했습니다.

`POST`로 `.../api/v1/location/nearby` 에 `longitude`, `latitude`, `keyword`로 mozi 서버에 요청을 보낼 수 있습니다. mozi 서버는 google api를 호출 한 뒤에 검색 결과에서 이름과 위치만 가져와서 반환해줍니다.

### 작업 사항

- axios를 이용해서 google api를 사용
- 검색 결과중에서 이름과 위치만 반환하는 api를 생성

### 변경후
![image](https://user-images.githubusercontent.com/44183313/188660241-2ca414a8-4564-4d19-9f35-8b0a51b07956.png)

### 기타
 `longitude`, `latitude` 순서에 관한 문제가 아주 많습니다. geoJSON이 경위도 순서이므로 이 순서를 따릅니다. 예를 들면, google api의 인자 순서는 위경도지만 mozi 서버의 인자 순서는 경위도( `longitude`, `latitude` )입니다.
