### PR TITLE
fix: jwt malformed 오류 해결

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -7,8 +7,8 @@ import config from '@/config';
 export const protect = async (req: Request, res: Response, next: NextFunction) => {
   if (req.headers.authorization && req.headers.authorization.startsWith('Bearer')) {
     const token = req.headers.authorization.split(' ')[1];
-    // console.log(token);
-    if (!token) {
+
+    if (token === 'null') {
       return res.status(401).json({ message: '토큰이 존재하지 않습니다.' });
     }
 
@@ -26,5 +26,5 @@ export const protect = async (req: Request, res: Response, next: NextFunction) =
     }
   }
 
-  res.status(401).json({ message: 'Not authorized, no token' });
+  return res.status(401).json({ message: 'Not authorized, no token' });
 };


### PR DESCRIPTION
### 개요

jwt.verfiy 함수 호출시 token 값이 제대로 전달되지 않으면 발생하는 오류 였다. 

```ts
  if (token === 'null') {
      return res.status(401).json({ message: '토큰이 존재하지 않습니다.' });
  }
```

전달되는 토큰의 null 체크를 한 번 해주었다. (null -> string)으로 옴.
JSON.parse를 해주려고 했으나, 다른 경우 token이 JSON 형태로 오지 않을 경우 에러를 유발하여 위와 같이 처리했다.