### PR TITLE
refactor: todo update 방법 변경

### DIFF
--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -30,11 +30,9 @@ export const deleteTodoHandler = async (req: Request, res: Response) => {
 };
 
 export const updateTodoHandler = async (req: Request, res: Response) => {
-  const affectedCount = await updateTodo(req.params.id, req.body);
+  const todo = await updateTodo(req.params.id, req.body);
 
-  const todo = await findTodo(req.params.id);
-
-  if (affectedCount) res.status(201).json(todo);
+  if (todo) res.status(201).json(todo);
   else throw 'Todo was not updated';
 };
 

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from 'uuid';
 import Todo from '@/models/todo';
 
 export const findAllTodos = async (ownerId: string) => {
@@ -10,37 +9,31 @@ export const findAllTodos = async (ownerId: string) => {
   return todos;
 };
 
-export const findTodo = async (id: string) => {
-  const todo = await Todo.findByPk(id);
+export const findTodo = async (todoId: string) => {
+  const todo = await Todo.findByPk(todoId);
   return todo;
 };
 
 export const createTodo = async (todo: any) => {
-  const newTodo = await Todo.create({ ...todo, id: uuid() });
+  const newTodo = await Todo.create({ ...todo });
   return newTodo;
 };
 
-export const deleteTodo = async (id: string) => {
+export const deleteTodo = async (todoId: string) => {
   const result = await Todo.destroy({
     where: {
-      id,
+      id: todoId,
     },
   });
   return result;
 };
 
-export const updateTodo = async (id: any, todo: any) => {
-  const [affectedCount] = await Todo.update(
-    {
-      ...todo,
-    },
-    {
-      where: {
-        id,
-      },
-    },
-  );
-  return affectedCount;
+export const updateTodo = async (todoId: string, newTodo: any) => {
+  const todo = await Todo.findByPk(todoId);
+  await todo?.update({
+    ...newTodo,
+  });
+  return todo;
 };
 
 export const deleteAllTodos = async (ownerId: string) => {


### PR DESCRIPTION
### 개요 (MOZI-216)

- todo update 과정에서 두 번 todo를 찾는 과정을 한 번으로 줄임

### 작업 사항

기존 구현 방법은 업데이트 할 todo를 찾고 업데이트 한 후에, 다시 todo를 찾아서 반환하게 했습니다.
`myTodo.update()` 라는 함수를 이용해서 업데이트 한 후에 바로 반환하게 해서 한 번만 찾습니다.

