### PR TITLE
feat: cross-env added

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "license": "MIT",
   "scripts": {
     "prestart": "rm -rf ./build && yarn build",
-    "start": "ts-node -r tsconfig-paths/register --files build/index.js",
-    "dev": "nodemon --exec ts-node -r tsconfig-paths/register --files ./src/index.ts",
+    "start": "cross-env NODE_ENV=production ts-node -r tsconfig-paths/register --files build/index.js",
+    "dev": "cross-env NODE_ENV=development nodemon --exec ts-node -r tsconfig-paths/register --files ./src/index.ts",
     "test": "jest --passWithNoTests",
     "lint": "eslint --fix src",
     "prepare": "husky install",
@@ -28,6 +28,7 @@
     "@types/yamljs": "^0.2.31",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
+    "cross-env": "^7.0.3",
     "eslint": "^8.19.0",
     "husky": "^8.0.1",
     "jest": "^28.1.2",

--- a/src/loaders/sequelize.ts
+++ b/src/loaders/sequelize.ts
@@ -1,8 +1,10 @@
 import mysql from 'mysql2/promise';
 import modelInit from '@/models';
+import logger from '@/utils/logger';
 
 const sequelizeLoader = async () => {
   const host = process.env.NODE_ENV === 'development' ? 'localhost' : 'db';
+  logger.info(`${host}, ${process.env.NODE_ENV}`);
   const connection = await mysql.createConnection({
     host,
     user: 'root',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,7 +1553,14 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
### 개요

`yarn start` 로 실행하건 `yarn dev`로 실행하건 `process.env.NODE_ENV` 가 `development`로 설정되어있는 문제가 있었습니다.
원래는 `production`으로 설정되어야합니다.

`cross-env`라는 모듈을 설치해서 `yarn start` 스크립트에 `cross-env NODE_ENV=production`를 추가했습니다.
`yarn dev` 스크립트에는 `cross-env NODE_ENV=development`를 추가했습니다.

맥 환경에서는 `cross-env`를 사용하지 않고 global로 스크립트에 `NODE_ENV=development`만 추가해주면 되지만 윈도우 환경에선 정상작동하지 않아서 `croos-env`를 설치했습니다.

### 작업 사항

- `cross-env` 모듈 설치
- `yarn start` 스크립트에 `cross-env NODE_ENV=production` 스크립트 추가.
- `yarn dev` 스크립트에 `cross-env NODE_ENV=development` 스크립트 추가.

### 변경후

![image](https://user-images.githubusercontent.com/44183313/191662711-a4c5db98-e6da-4c7c-a4c8-a3ccf4142df1.png)

`yarn start`를 `logger`로 출력한 결과 `NODE_ENV`가 `production`으로 출력됩니다.
