### PR TITLE
feat: todo soft delete

### DIFF
--- a/src/loaders/sequelize.ts
+++ b/src/loaders/sequelize.ts
@@ -1,10 +1,8 @@
 import mysql from 'mysql2/promise';
 import modelInit from '@/models';
-import logger from '@/utils/logger';
 
 const sequelizeLoader = async () => {
   const host = process.env.NODE_ENV === 'development' ? 'localhost' : 'db';
-  logger.info(`${host}, ${process.env.NODE_ENV}`);
   const connection = await mysql.createConnection({
     host,
     user: 'root',

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -54,6 +54,7 @@ const todoInit = (sequelize: Sequelize) => {
     },
     {
       tableName: 'todos',
+      paranoid: true,
       sequelize,
     },
   );

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -6,16 +6,23 @@ export const findAllTodos = async (ownerId: string) => {
       ownerId,
     },
   });
+
   return todos;
 };
 
 export const findTodo = async (todoId: string) => {
-  const todo = await Todo.findByPk(todoId);
+  const todo = await Todo.findOne({
+    where: {
+      id: todoId,
+    },
+  });
+
   return todo;
 };
 
-export const createTodo = async (todo: any) => {
+export const createTodo = async (todo: Todo) => {
   const newTodo = await Todo.create({ ...todo });
+
   return newTodo;
 };
 
@@ -25,11 +32,20 @@ export const deleteTodo = async (todoId: string) => {
       id: todoId,
     },
   });
+
   return result;
 };
 
 export const updateTodo = async (todoId: string, newTodo: any) => {
-  const updatedTodo = await Todo.update({ ...newTodo }, { where: { id: todoId } });
+  const updatedTodo = await Todo.findOne({
+    where: {
+      id: todoId,
+    },
+  });
+
+  await updatedTodo?.update({
+    ...newTodo,
+  });
 
   return updatedTodo;
 };


### PR DESCRIPTION
### 개요

`Todo`의 `sequelize init` 함수에 `paranoid: true` 옵션을 추가해서 Soft delete가 가능하게 바꾸었습니다.

Soft delete 하는 법
```TS
await Todo.destroy({
  where: {
    id: 'c2e2c244-45f5-45c0-8b8c-061d2d6e4af3'
  }
});
```

Hard delete 하는 법
```TS
await Todo.destroy({
  where: {
    id: 'c2e2c244-45f5-45c0-8b8c-061d2d6e4af3'
  },
  force: true
});
```
힘을 줘서 지우면 됩니다.

### 작업 사항

- `paranoid: true`옵션 추가
-  todo service의 updateTodo가 Todo를 반환하게 변경

### 변경후

![image](https://user-images.githubusercontent.com/44183313/191892015-e03e6ef7-88c3-4819-951c-20ba8fe14064.png)

![image](https://user-images.githubusercontent.com/44183313/191892006-a65e7478-bbea-42ce-ab75-37097bf88d41.png)

삭제한 후에도 `mysql`에서 raw Query를 통해서 삭제한 Todo를 확인할 수 있습니다.

[Sequelize how to soft delete](https://sequelize.org/docs/v6/core-concepts/paranoid/)
