### PR TITLE
chore: merge 되는 경우만 CD & docker 내부 시간 한국으로 맞추기

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,8 +3,6 @@ name: CD
 on:
   push:
     branches: [develop]
-  pull_request:
-    branches: [develop]
 
 jobs:
   CD:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=mozi
+      - TZ=Asia/Seoul
     volumes:
       - ./db:/var/lib/mysql
     networks:
@@ -20,6 +21,8 @@ services:
       - ./nginx:/etc/nginx/conf.d
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
+    environment:
+      - TZ=Asia/Seoul
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     ports:
@@ -43,6 +46,8 @@ services:
     networks:
       mozinetwork:
         ipv4_address: 172.23.0.9
+    environment:
+      - TZ=Asia/Seoul
     ports:
       - '3001:3001'
     depends_on:


### PR DESCRIPTION
### MOZI-243
- docker logs했을때 시간을 정확히 보기 위해 시간 설정도 했습니다.

### CD
CD가 PR을 날렸을때도 될 이유가 없어서 뺐어요 :)

