### PR TITLE
feat: todo, user interface added

### DIFF
--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,0 +1,22 @@
+import User from './user';
+
+interface Todo {
+  id?: string;
+
+  ownerId?: string;
+  owner?: User;
+
+  title: string;
+  description: string;
+
+  done?: boolean;
+  alarmed?: boolean;
+
+  locationName?: string;
+  longitude?: number;
+  latitude?: number;
+
+  index?: number;
+}
+
+export default Todo;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,17 @@
+import Todo from './todo';
+
+interface User {
+  id?: string;
+
+  name: string;
+  email: string;
+  password?: string;
+
+  todos?: Todo[];
+
+  image?: string;
+  thumbnailImage?: string;
+  profileImage?: string;
+}
+
+export default User;


### PR DESCRIPTION
### 개요

`sequelize`의 `Model`을 `extends`한 `Todo` 모델이나 `User` 모델은 모델 관계를 위해서 추가된 `add...` 등의 필드가 많아서 타입 체킹용으로 사용하긴 부적절한 것 같습니다. 그래서 거의 똑같지만 interface를 별도로 정의했습니다.

### 작업 사항

- todo interface
- user interface