### PR TITLE
feat: Todo ownerId 필드 이름을 userId로 변경

### DIFF
--- a/src/controllers/todo.ts
+++ b/src/controllers/todo.ts
@@ -16,7 +16,7 @@ export const getTodoHandler = async (req: Request, res: Response) => {
 
 export const createTodoHandler = async (req: Request, res: Response) => {
   const todo = await createTodo({
-    ownerId: req.user.id,
+    userId: req.user.id,
     ...req.body,
   });
   res.status(201).json(todo);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -15,7 +15,6 @@ const userInit = (sequelize: Sequelize) => {
       email: DataTypes.STRING,
       password: DataTypes.STRING,
 
-      image: DataTypes.STRING,
       thumbnailImage: DataTypes.STRING,
       profileImage: DataTypes.STRING,
     },

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -64,7 +64,7 @@ const todoInit = (sequelize: Sequelize) => {
 const todoUserInit = () => {
   User.hasMany(Todo, {
     sourceKey: 'id',
-    foreignKey: 'ownerId',
+    foreignKey: 'userId',
     as: 'todos',
   });
 };

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -4,7 +4,7 @@ import User from '@/models/user';
 class Todo extends Model<InferAttributes<Todo>, InferCreationAttributes<Todo>> {
   declare id: CreationOptional<string>;
 
-  declare ownerId: ForeignKey<User['id']>;
+  declare userId: ForeignKey<User['id']>;
   declare owner?: NonAttribute<User>;
 
   declare title: string;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -36,7 +36,7 @@ class User extends Model<InferAttributes<User, { omit: 'todos' }>, InferCreation
   declare hasTodo: HasManyHasAssociationMixin<Todo, number>;
   declare hasTodos: HasManyHasAssociationsMixin<Todo, number>;
   declare countTodos: HasManyCountAssociationsMixin;
-  declare createTodo: HasManyCreateAssociationMixin<Todo, 'ownerId'>;
+  declare createTodo: HasManyCreateAssociationMixin<Todo, 'userId'>;
 
   declare todos?: NonAttribute<Todo[]>;
 

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -24,7 +24,6 @@ class User extends Model<InferAttributes<User, { omit: 'todos' }>, InferCreation
   declare name: string;
   declare email: string;
   declare password?: string;
-  declare image?: string;
   declare thumbnailImage?: string;
   declare profileImage?: string;
 

--- a/src/services/todo.ts
+++ b/src/services/todo.ts
@@ -1,9 +1,9 @@
 import Todo from '@/models/todo';
 
-export const findAllTodos = async (ownerId: string) => {
+export const findAllTodos = async (userId: string) => {
   const todos = await Todo.findAll({
     where: {
-      ownerId,
+      userId,
     },
     paranoid: false,
   });
@@ -53,10 +53,10 @@ export const updateTodo = async (todoId: string, newTodo: any) => {
   return updatedTodo;
 };
 
-export const deleteAllTodos = async (ownerId: string) => {
+export const deleteAllTodos = async (userId: string) => {
   const result = await Todo.destroy({
     where: {
-      ownerId,
+      userId,
     },
   });
 

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -3,7 +3,7 @@ import User from './user';
 interface Todo {
   id?: string;
 
-  ownerId?: string;
+  userId?: string;
   owner?: User;
 
   title: string;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -9,7 +9,6 @@ interface User {
 
   todos?: Todo[];
 
-  image?: string;
   thumbnailImage?: string;
   profileImage?: string;
 }


### PR DESCRIPTION
### 개요

- `ownerId` -> `userId`

### 작업 사항

- `ownerId` -> `userId`
- 추가적으로 `User` 스키마의 `image`가 `profileImage`와 중복되는 필드라서 삭제

### 변경후

![image](https://user-images.githubusercontent.com/44183313/193543850-5d209173-3a06-4946-8716-3953bbefa86e.png)
