### PR TITLE
feat: Todo에 dueDate, alarmDate 추가

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -46,6 +46,9 @@ const todoInit = (sequelize: Sequelize) => {
         defaultValue: false,
       },
 
+      dueDate: DataTypes.DATE,
+      alarmDate: DataTypes.DATE,
+
       locationName: DataTypes.STRING,
       longitude: DataTypes.FLOAT,
       latitude: DataTypes.FLOAT,

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -13,6 +13,9 @@ class Todo extends Model<InferAttributes<Todo>, InferCreationAttributes<Todo>> {
   declare done: CreationOptional<boolean>;
   declare alarmed: CreationOptional<boolean>;
 
+  declare dueDate: CreationOptional<Date>;
+  declare alarmDate: CreationOptional<Date>;
+
   declare locationName: CreationOptional<string>;
   declare longitude: CreationOptional<number>;
   declare latitude: CreationOptional<number>;

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -12,6 +12,9 @@ interface Todo {
   done?: boolean;
   alarmed?: boolean;
 
+  dueDate?: Date;
+  alarmDate?: Date;
+
   locationName?: string;
   longitude?: number;
   latitude?: number;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -10,12 +10,15 @@ servers:
 paths:
   /todos:
     get:
-      summary: 사용자의 모든 Todo를 가져옵니다.
       tags:
         - 'Todo'
+
+      summary: 사용자의 모든 Todo를 가져옵니다.
+
       responses:
         '200':
           description: 성공
+
           content:
             application/json:
               schema:
@@ -68,12 +71,16 @@ paths:
                       'deletedAt': null,
                     },
                   ]
+
       security:
         - bearerAuth: []
+
     post:
       tags:
         - Todo
+
       summary: Todo를 DB에 생성하고 생성한 Todo를 가져옵니다.
+
       requestBody:
         description: 새로 생성할 Todo
         content:
@@ -81,6 +88,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Todo'
         required: true
+
       responses:
         '201':
           description: 성공
@@ -88,15 +96,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Todo'
+
       security:
         - bearerAuth: []
-        
+
   /todos/{id}:
     get:
-      summary: ID를 통해서 Todo를 가져옵니다.
       tags:
         - 'Todo'
+
       summary: ID를 통해서 Todo를 가져옵니다.
+
       parameters:
         - name: id
           in: path
@@ -104,6 +114,7 @@ paths:
           required: true
           schema:
             type: string
+
       responses:
         '200':
           description: '성공'
@@ -111,13 +122,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Todo'
+
       security:
         - bearerAuth: []
+
     delete:
-      summary: ID를 통해서 Todo를 삭제합니다.
       tags:
         - 'Todo'
+
       summary: ID를 통해서 Todo를 삭제합니다.
+
       parameters:
         - name: id
           in: path
@@ -125,27 +139,31 @@ paths:
           required: true
           schema:
             type: string
+
       responses:
         '200':
           description: 성공
           examples:
             application/json: 1
+
       security:
         - bearerAuth: []
+
     patch:
-      summary: ID를 통해서 Todo를 업데이트합니다.
       tags:
         - 'Todo'
+
       summary: ID를 통해서 Todo를 업데이트합니다.
+
       parameters:
         - name: id
           in: path
           description: 업데이트하려는 Todo의 ID(uuid)
           required: true
           type: object
-          description: 새로 업데이트할 Todo
           schema:
             type: string
+
       requestBody:
         description: 새로 업데이트할 Todo
         content:
@@ -153,6 +171,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Todo'
         required: true
+
       responses:
         '201':
           description: 성공
@@ -160,15 +179,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Todo'
+
       security:
         - bearerAuth: []
 
   /location/nearby:
     post:
-      summary: 경위도와 주어진 키워드를 기준으로 장소를 검색해서 가져옵니다.
       tags:
         - 'location'
+
       summary: 경위도와 주어진 키워드를 기준으로 장소를 검색해서 가져옵니다.
+
       requestBody:
         description: 경위도와 키워드
         content:
@@ -176,6 +197,7 @@ paths:
             schema:
               $ref: '#/components/schemas/LocationSearch'
         required: true
+
       responses:
         '200':
           description: '성공'
@@ -189,6 +211,7 @@ paths:
                     { 'name': '스타벅스 선릉동신빌딩R점', 'location': [127.050481, 37.5052818] },
                     { 'name': '스타벅스 선릉로점', 'location': [127.0467617, 37.5049945] },
                   ]
+
 components:
   schemas:
     User:
@@ -212,6 +235,7 @@ components:
           example: http://k.kakaocdn.net/dn/JzzMA/btrzvznKm3k/TgW0XNHcLGwJjJXXiidjp0/img_640x640.jpg
         todos:
           type: Todo[]
+
     Todo:
       type: object
       properties:
@@ -233,6 +257,8 @@ components:
         alarmed:
           type: boolean
           example: false
+        dueDate:
+          type: string
         locationName:
           type: string
           example: 선릉역
@@ -245,6 +271,7 @@ components:
         index:
           type: number
           example: 1
+
     LocationSearch:
       type: object
       properties:
@@ -257,6 +284,7 @@ components:
         latitude:
           type: number
           example: 37.50466496606413
+
   securitySchemes:
     bearerAuth:
       type: http

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -32,6 +32,8 @@ paths:
                       'description': 'what was it?',
                       'done': false,
                       'alarmed': false,
+                      'dueDate': '2022-10-04T20:15:00.000Z',
+                      'alarmDate': '2022-10-04T20:15:00.000Z',
                       'locationName': '',
                       'longitude': null,
                       'latitude': null,
@@ -47,6 +49,8 @@ paths:
                       'description': 'buy now',
                       'done': false,
                       'alarmed': false,
+                      'dueDate': '2022-10-04T20:15:00.000Z',
+                      'alarmDate': '2022-10-04T20:15:00.000Z',
                       'locationName': '',
                       'longitude': null,
                       'latitude': null,
@@ -62,6 +66,8 @@ paths:
                       'description': 'are belong to you',
                       'done': false,
                       'alarmed': false,
+                      'dueDate': '2022-10-04T20:15:00.000Z',
+                      'alarmDate': '2022-10-04T20:15:00.000Z',
                       'locationName': '',
                       'longitude': null,
                       'latitude': null,
@@ -259,6 +265,12 @@ components:
           example: false
         dueDate:
           type: string
+          format: date-time
+          example: '2022-10-04T20:15:00.000Z'
+        alarmDate:
+          type: string
+          format: date-time
+          example: '2022-10-04T20:15:00.000Z'
         locationName:
           type: string
           example: 선릉역


### PR DESCRIPTION
### 개요 (MOZI-306)

- `Todo`에 `dueDate`, `alarmDate` 필드를 추가했습니다.

### 작업 사항

- `Todo`에 `dueDate`, `alarmDate` 필드를 추가
- api 문서도 따라서 업데이트

### 기타
```typescript
const newTodo = {
  title: 'hello',
  description: 'what is this?',
  locationName: '충남대 도서관',
  dueDate: '2022-10-04T20:15:00.000Z',
  alarmDate: '2022-10-04T20:15:00.000Z',
  longitude: 123,
  latitude: 47,
};
```
API 사용시 `req.body`에 `dueDate`나 `alarmDate`를 형식에 맞는 문자열로 넣어주면 됩니다.