### PR TITLE
feat: Prometheus client middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,13 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
+    "express-prom-bundle": "^6.5.0",
     "helmet": "^5.1.1",
     "http-errors": "^2.0.0",
     "jsonwebtoken": "^8.5.1",
     "mysql2": "^2.3.3",
     "pino": "^8.4.2",
+    "prom-client": "^14.1.0",
     "sequelize": "^6.21.4",
     "web-push": "^3.5.0",
     "zod": "^3.19.1"

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -3,11 +3,12 @@ import express from 'express';
 import expressLoader from '@/loaders/express';
 import { routesLoader } from './routes';
 import sequelizeLoader from './sequelize';
+import promLoader from './prom';
 
 const loader = async (app: express.Application) => {
   expressLoader(app);
   await sequelizeLoader();
-
+  promLoader(app);
   routesLoader(app);
 };
 

--- a/src/loaders/prom.ts
+++ b/src/loaders/prom.ts
@@ -1,0 +1,13 @@
+import { Application } from 'express';
+import promBundle from 'express-prom-bundle';
+
+const promLoader = (app: Application) => {
+  const metricsMiddleware = promBundle({
+    includeMethod: true,
+    includePath: true,
+  });
+
+  app.use(metricsMiddleware);
+};
+
+export default promLoader;

--- a/tests/todo.test.ts
+++ b/tests/todo.test.ts
@@ -18,26 +18,26 @@ const updatedTodo: Todo = {
   latitude: 47,
 };
 
+let app: any;
+
+beforeAll(async () => {
+  app = await getServer();
+});
+
 describe('Todo service', () => {
   test('GET /api/v1/todos', async () => {
-    const app = await getServer();
-
     const todos = await getAllTodos(app);
 
     expect(Array.isArray(todos)).toBeTruthy();
   });
 
   test('POST /api/v1/todos', async () => {
-    const app = await getServer();
-
     const todo = await createTodo(app, newTodo);
 
     expect(todo).toMatchObject(newTodo);
   });
 
   test('PATCH /api/v1/todos', async () => {
-    const app = await getServer();
-
     const [firstTodo] = await getAllTodos(app);
     const { id } = firstTodo;
 
@@ -47,8 +47,6 @@ describe('Todo service', () => {
   });
 
   test('DELETE /api/v1/todos', async () => {
-    const app = await getServer();
-
     const [firstTodo] = await getAllTodos(app);
     const { id } = firstTodo;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,6 +1272,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
+
 bn.js@^4.0.0:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
@@ -2007,6 +2012,14 @@ expect@^29.0.0:
     jest-matcher-utils "^29.1.2"
     jest-message-util "^29.1.2"
     jest-util "^29.1.2"
+
+express-prom-bundle@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/express-prom-bundle/-/express-prom-bundle-6.5.0.tgz#cdf28b29907618cae933ed14d5b727f7404e810b"
+  integrity sha512-paFAm0FK7TV1Ln6Blh9edDt2mJ4Pk6Py/fjhZDMcoMHENYryBjCpnXDXuCu8NE1kkvp58IrPcAAkNeNqdvZnnw==
+  dependencies:
+    on-finished "^2.3.0"
+    url-value-parser "^2.0.0"
 
 express@^4.18.1:
   version "4.18.1"
@@ -3543,7 +3556,7 @@ on-exit-leak-free@^2.1.0:
   resolved "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz"
   integrity sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -3781,6 +3794,13 @@ process-warning@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz"
   integrity sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww==
+
+prom-client@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.1.0.tgz#049609859483d900844924df740722c76ed1fdbb"
+  integrity sha512-iFWCchQmi4170omLpFXbzz62SQTmPhtBL35v0qGEVRHKcqIeiexaoYeP0vfZTujxEq3tA87iqOdRbC9svS1B9A==
+  dependencies:
+    tdigest "^0.1.1"
 
 prompts@^2.0.1:
   version "2.4.2"
@@ -4377,6 +4397,13 @@ tar@^6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
+
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz"
@@ -4573,6 +4600,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-value-parser@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/url-value-parser/-/url-value-parser-2.2.0.tgz#f38ae8cd24604ec69bc219d66929ddbbd93a2b32"
+  integrity sha512-yIQdxJpgkPamPPAPuGdS7Q548rLhny42tg8d4vyTNzFqvOnwqrgHXvgehT09U7fwrzxi3RxCiXjoNUNnNOlQ8A==
 
 urlsafe-base64@^1.0.0, urlsafe-base64@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### 개요 (MOZI-328)

- 서버의 Metrics를 `Prometheus` 인스턴스로 보내주는 `prom-client` 모듈을 설치했습니다.
- `express-prom-bundle` 모듈을 이용해서 전반적인 `http`요청의 `count`, `sum` metrics를 수집해주는 middleware를 달아줬습니다.
- `Grafana`에서 `Prometheus` 인스턴스를 등록하면 Metrics를 시각화해서 확인할 수 있습니다.

### 작업 사항

- `prom-client` 추가
- `express-prom-bundle` 추가

### 변경후
![image](https://user-images.githubusercontent.com/44183313/196027046-2202fbf2-d5cf-4613-9a3b-7d1c4e9f5c5d.png)

### 기타
적절한 데이터를 수집하고 시각화하기 위해서는 `prom-client`와 `Grafana`를 추가적으로 조정해야합니다.
하드웨어적인 Metrics를 수집하기 위해서는 컴퓨터에 `Node-exporter`를 설치해줘야합니다.