### PR TITLE
fix: Exception handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,6 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/no-unused-vars": ["error"],
     "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,5 @@ const startSever = async () => {
 startSever();
 
 process.on('unhandledRejection', (error) => console.log(error));
+
+process.on('uncaughtException', (error) => console.log(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import express, { Application } from 'express';
+import express from 'express';
 import webpush from 'web-push';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import express from 'express';
+import express, { Application } from 'express';
 import webpush from 'web-push';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
@@ -12,7 +12,7 @@ const privateVapidKey = 'QNapwA1rlszq7UdCqLo5s5aORi5jAAlCEFMEfZaw4tU';
 
 webpush.setVapidDetails('mailto:leehj0110@kakao.com', publicVapidKey, privateVapidKey);
 
-export const getServer = async () => {
+const getServer = async () => {
   const app = express();
 
   Sentry.init({

--- a/src/loaders/routes.ts
+++ b/src/loaders/routes.ts
@@ -16,15 +16,15 @@ export const routesLoader = (app: express.Application) => {
   app.use(Sentry.Handlers.errorHandler());
 
   // eslint-disable-next-line
-  app.use((err: HttpError | ZodError, req: Request, res: Response, next: NextFunction) => {
+  app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
     if (err instanceof ZodError) {
       return res.status(400).json(err);
     }
 
-    if (!('status' in err)) {
-      return res.status(500).json(err);
+    if (err instanceof HttpError) {
+      return res.status(err.status).json(err);
     }
 
-    return res.status(err.status).json(err);
+    return res.status(500).json(err);
   });
 };

--- a/src/loaders/routes.ts
+++ b/src/loaders/routes.ts
@@ -15,7 +15,6 @@ export const routesLoader = (app: express.Application) => {
   // The error handler must be before any other error middleware and after all controllers
   app.use(Sentry.Handlers.errorHandler());
 
-  // eslint-disable-next-line
   app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
     if (err instanceof ZodError) {
       return res.status(400).json(err);

--- a/src/loaders/routes.ts
+++ b/src/loaders/routes.ts
@@ -9,7 +9,7 @@ export const routesLoader = (app: express.Application) => {
   app.use('/api/v1', routes);
 
   app.use('/', (req: Request, res: Response, next: NextFunction) => {
-    next(new createHttpError.NotFound('No such page'));
+    res.status(404).send('Page not found');
   });
 
   // The error handler must be before any other error middleware and after all controllers

--- a/src/loaders/routes.ts
+++ b/src/loaders/routes.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
-import createHttpError, { HttpError } from 'http-errors';
+import { HttpError } from 'http-errors';
 import * as Sentry from '@sentry/node';
 import { ZodError } from 'zod';
 

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -22,7 +22,7 @@ export const protect = async (req: Request, res: Response, next: NextFunction) =
       return next();
     } catch (error) {
       console.log(error);
-      res.status(401).json({ message: 'id로 유저를 찾는데 실패했습니다.' });
+      return res.status(401).json({ message: 'id로 유저를 찾는데 실패했습니다.' });
     }
   }
 

--- a/tests/todo.test.ts
+++ b/tests/todo.test.ts
@@ -1,4 +1,6 @@
-import { getServer } from '../src/index';
+import express, { Application } from 'express';
+import loader from '../src/loaders';
+
 import { createTodo, deleteTodo, getAllTodos, updateTodo } from './todo';
 import Todo from '../src/types/todo';
 
@@ -18,10 +20,11 @@ const updatedTodo: Todo = {
   latitude: 47,
 };
 
-let app: any;
+let app: Application;
 
 beforeAll(async () => {
-  app = await getServer();
+  app = express();
+  await loader(app);
 });
 
 describe('Todo service', () => {


### PR DESCRIPTION
### 개요

- Exception handling 방식을 수정했습니다.
- `eslint`의 `no-unused-vars` 옵션을 삭제했습니다.
- 기타 오타 수정 

### 작업 사항

- `eslint`의 `no-unused-vars` 옵션을 삭제했습니다.
  `Express`의 Error handling middleware의 시그니쳐는 `(err, res, req, next)`인데 여기서 `next`가 사용되지 않아서 제거해야하는 바람에 `(req, res, next)`와 같은 시그니쳐가 되어서 버그가 발생했습니다.