### PR TITLE
feat: Map에서 주변이 아닌 장소도 검색할 수 있는 기능

### DIFF
--- a/src/controllers/location.ts
+++ b/src/controllers/location.ts
@@ -1,6 +1,18 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 
-import { getNearby, getTodosWithLocation } from '@/services/location';
+import { instantSearch, getNearby, getTodosWithLocation } from '@/services/location';
+
+export const instantSearchHandler = async (req: Request, res: Response, next: NextFunction) => {
+  const { longitude, latitude, keyword } = req.body;
+
+  try {
+    const locations = await instantSearch(longitude, latitude, keyword);
+
+    return res.status(200).json(locations);
+  } catch (error: unknown) {
+    return next();
+  }
+};
 
 export const getNearbyHandler = async (req: Request, res: Response) => {
   const { longitude, latitude, keyword } = req.body;

--- a/src/middlewares/location.ts
+++ b/src/middlewares/location.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+import z from 'zod';
+
+export const locationValidator = (req: Request, res: Response, next: NextFunction) => {
+  const locationSchema = z.object({
+    locationName: z.string().optional(),
+    longitude: z.number().gte(-180).lte(180).optional(),
+    latitude: z.number().gte(-90).lte(90).optional(),
+  });
+
+  locationSchema.parse(req.body);
+
+  return next();
+};

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -1,10 +1,10 @@
 import express from 'express';
 
-import { getNearbyHandler, getTodosWithLocationsHandler } from '@/controllers/location';
+import { instantSearchHandler, getNearbyHandler, getTodosWithLocationsHandler } from '@/controllers/location';
 
 const locationRouter = express.Router();
 
 locationRouter.get('/', getTodosWithLocationsHandler);
-locationRouter.post('/nearby', getNearbyHandler);
+locationRouter.post('/nearby', instantSearchHandler, getNearbyHandler);
 
 export default locationRouter;

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 
 import { instantSearchHandler, getNearbyHandler, getTodosWithLocationsHandler } from '@/controllers/location';
+import { locationValidator } from '@/middlewares/location';
 
 const locationRouter = express.Router();
 
 locationRouter.get('/', getTodosWithLocationsHandler);
-locationRouter.post('/nearby', instantSearchHandler, getNearbyHandler);
+locationRouter.post('/nearby', locationValidator, instantSearchHandler, getNearbyHandler);
 
 export default locationRouter;

--- a/src/services/location.ts
+++ b/src/services/location.ts
@@ -5,37 +5,32 @@ import Todo from '@/models/todo';
 
 dotenv.config();
 
+type location = {
+  name: string;
+  location: [number];
+};
+
 const googleNearBySearchApiUrl = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json';
 
-const request = async (longitude: number, latitude: number, keyword: string) => {
-  // geoJSON 형식과는 다르게 (latitude, longitude) 순서임
-  const location = `${latitude},${longitude}`;
-  const rankby = 'distance';
-  const language = 'ko';
-  const key = process.env.GOOGLE_NEARBYSEARCH_API_KEY;
-
+const nearbyRequest = async (longitude: number, latitude: number, keyword: string) => {
   const {
     data: { results },
   } = await axios.get(googleNearBySearchApiUrl, {
     params: {
-      location,
+      location: `${latitude},${longitude}`,
       keyword,
-      rankby,
-      language,
-      key,
+      rankby: 'distance',
+      language: 'ko',
+      key: process.env.GOOGLE_NEARBYSEARCH_API_KEY,
     },
   });
 
   return results;
 };
 
-type location = {
-  name: string;
-  location: [number];
-};
-
 export const getNearby = async (longitude: number, latitude: number, keyword: string) => {
-  const results = await request(longitude, latitude, keyword);
+  const results = await nearbyRequest(longitude, latitude, keyword);
+
   const locations: location[] = results.map((result: any) => {
     const {
       name,
@@ -49,6 +44,38 @@ export const getNearby = async (longitude: number, latitude: number, keyword: st
     };
   });
   return locations;
+};
+
+const naverInstantSearchUrl = 'https://map.naver.com/v5/api/instantSearch';
+
+const instantRequest = async (longitude: number, latitude: number, query: string) => {
+  const {
+    data: { place: locations },
+    status,
+  } = await axios.get(naverInstantSearchUrl, {
+    params: {
+      coords: `${latitude},${longitude}`,
+      query,
+    },
+    timeout: 200,
+  });
+
+  if (status != 200) throw 'instant search failed';
+
+  return locations;
+};
+
+export const instantSearch = async (longitude: number, latitude: number, query: string) => {
+  const locations = await instantRequest(longitude, latitude, query);
+
+  return locations.map((location: any) => {
+    const { title: name, x: longitude, y: latitude } = location;
+
+    return {
+      name,
+      location: [parseFloat(longitude), parseFloat(latitude)],
+    };
+  });
 };
 
 export const getTodosWithLocation = async () => {

--- a/tests/location.test.ts
+++ b/tests/location.test.ts
@@ -1,0 +1,49 @@
+import express, { Application } from 'express';
+import z from 'zod';
+import request from 'supertest';
+
+import loader from '../src/loaders/index';
+
+let app: Application;
+
+beforeAll(async () => {
+  app = express();
+  await loader(app);
+});
+
+const locationSchema = z.object({
+  name: z.string(),
+  location: z.number().array().length(2),
+});
+
+const search = async (longitude: number, latitude: number, keyword: string) => {
+  return await request(app)
+    .post(`/api/v1/location/nearby`)
+    .send({
+      longitude,
+      latitude,
+      keyword,
+    })
+    .expect(200);
+};
+
+const data = {
+  // 대전
+  longitude: 127.33338864606384,
+  latitude: 36.36542770000048,
+  keyword: '서울 스타벅스',
+};
+
+describe('InstantSearch', () => {
+  test('Far away Search', async () => {
+    const { longitude, latitude, keyword } = data;
+    const { body: locations } = await search(longitude, latitude, keyword);
+
+    for (const location of locations) {
+      console.log(location);
+
+      const { success } = locationSchema.safeParse(location);
+      expect(success).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
### 개요 (MOZI-337)

기존의 google `nearbySearch API`는 주어진 `longitude` `latitude` `keyword` 를 기준으로 가장 가까운 장소 검색 결과를 반환합니다.

만약 사용자가 대전에 위치한 상태로 `Map`에서 `서울 스타벅스`를 검색하면 아무련 결과도 얻을 수 없습니다. 물리적으로 너무 먼 거리이기 때문입니다.

이제 네이버 지도의 검색 기능을 이용해서 더 편하게 장소를 검색할 수 있습니다. 네이버 지도 검색 기능과 `nearbySearch API` 둘 중 하나의 검색 결과를 반환합니다.

### 작업 사항

- 네이버 지도 검색 기능을 사용하는 `InstantSearch` 기능 작성
- 기존 `NearbySearch` 컨트롤러 앞에 `InstantSearch` 컨트롤러를 위치시켜서 우선순위를 설정.

### 변경후
![image](https://user-images.githubusercontent.com/44183313/197458429-3506223f-408e-49b6-9245-ee29bd6a9ac6.png)

사용자가 위치한 물리적인 위치는 대전이지만, `서울 스타벅스`를 검색하고 해당 위치로 `Map`을 이동시킬 수 있습니다.
