### PR TITLE
feat: Todo Update API endpoint 변경

### DIFF
--- a/src/todos/todosController.ts
+++ b/src/todos/todosController.ts
@@ -80,18 +80,12 @@ export class TodosController extends Controller {
    * 사용자의 Todo를 업데이트합니다.
    * @param id 업데이트할 Todo의 UUID
    * @param reqBody 업데이트할 Todo의 값
-   * @param restore 삭제된 Todo라면 복구합니다.
    * @summary 사용자의 Todo를 업데이트합니다.
    */
   @SuccessResponse('204', 'No contents')
   @Patch('{id}')
-  public async updateTodo(
-    @Path() id: string,
-    @Request() req: express.Request,
-    @Body() reqBody: TodoValidationParams,
-    @Query() restore = false,
-  ) {
-    await new TodosService().update(req.user, id, reqBody, restore);
+  public async updateTodo(@Path() id: string, @Request() req: express.Request, @Body() reqBody: TodoValidationParams) {
+    await new TodosService().update(req.user, id, reqBody);
   }
 
   /**

--- a/src/todos/todosService.ts
+++ b/src/todos/todosService.ts
@@ -54,7 +54,7 @@ export class TodosService {
     }
   }
 
-  public async update(user: User, todoId: string, params: TodoValidationParams, restore = false) {
+  public async update(user: User, todoId: string, params: TodoValidationParams) {
     const [todo] = await user.getTodos({
       where: {
         id: todoId,
@@ -69,8 +69,11 @@ export class TodosService {
     const todoCreationParams = extractTodoCreationParams(params);
     await todo.update(todoCreationParams);
 
-    if (restore) {
+    if (params.deletedAt === null || params.deletedAt === undefined) {
       await todo.restore();
+    } else {
+      todo.setDataValue('deletedAt' as any, params.deletedAt);
+      await todo.save();
     }
 
     return todo;
@@ -88,8 +91,8 @@ export class TodosService {
       await todo.restore();
     } else {
       todo.setDataValue('deletedAt' as any, params.deletedAt);
+      await todo.save();
     }
-    await todo.save();
 
     return todo;
   }

--- a/src/todos/todosService.ts
+++ b/src/todos/todosService.ts
@@ -1,6 +1,6 @@
 import { User } from '@/users/user';
 import { extractTodoCreationParams, Todo } from '@/todos/todo';
-import { TodoCreationParams, TodoValidationParams } from './todo';
+import { TodoValidationParams } from './todo';
 import { WhereOptions } from 'sequelize/types';
 import { todoNotFound } from '@/utils/error';
 

--- a/tests/todos/todos.test.ts
+++ b/tests/todos/todos.test.ts
@@ -207,7 +207,7 @@ describe('PATCH /todos/{id}', () => {
     const updateParams = new MockTodoCreationParams();
     await request(app, 'patch', `/api/v1/todos/${todo.id}`, token).send(updateParams).expect(204);
 
-    expect(matches(updateParams, todo.id)).toBeTruthy();
+    expect(await matches(updateParams, todo.id)).toBeTruthy();
   });
 
   test('update failed', async () => {
@@ -229,15 +229,26 @@ describe('PATCH /todos/{id}', () => {
     const updateParams = new MockTodoCreationParams();
     await request(app, 'patch', `/api/v1/todos/${todo.id}`, token).send(updateParams).expect(204);
 
-    expect(matches(updateParams, todo.id)).toBeTruthy();
+    expect(await matches(updateParams, todo.id)).toBeTruthy();
   });
 
   test('restore deleted todo', async () => {
     const todo = await createTodo(user, true);
+    // updateParams.deletedAt은 존재하지 않기 때문에 Todo는 복구되어야 합니다.
     const updateParams = new MockTodoCreationParams();
-    await request(app, 'patch', `/api/v1/todos/${todo.id}?restore=true`, token).send(updateParams).expect(204);
+    await request(app, 'patch', `/api/v1/todos/${todo.id}`, token).send(updateParams).expect(204);
 
-    expect(matches(updateParams, todo.id, true)).toBeTruthy();
+    expect(await matches(updateParams, todo.id, true)).toBeTruthy();
+  });
+
+  test('delete todo', async () => {
+    const todo = await createTodo(user);
+    // updateParams.deletedAt을 지정해서 삭제할 수 있습니다.
+    const updateParams: any = new MockTodoCreationParams();
+    updateParams.deletedAt = new Date();
+    await request(app, 'patch', `/api/v1/todos/${todo.id}`, token).send(updateParams).expect(204);
+
+    expect(await matches(updateParams, todo.id, true)).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
### 개요

- `PATCH /todos/{id}?restore=true`를 `PATCH /todos/{id}`로 변경하고 request body에 `deletedAt`을 포함하거나 포함하지 않으면 삭제하거나 삭제하지 않게 구현했습니다.

### 작업 사항

- `PATCH /todos/{id}?restore=true`를 `PATCH /todos/{id}`로 변경
- 테스트 코드 작성
