### PR TITLE
fix: todos 중복 생성

### DIFF
--- a/src/todos/todo.ts
+++ b/src/todos/todo.ts
@@ -92,6 +92,8 @@ export interface TodoValidationParams {
 }
 
 export interface TodoCreationParams {
+  id?: string;
+
   title?: string;
   description?: string;
 
@@ -110,6 +112,8 @@ export interface TodoCreationParams {
 
 export const extractTodoCreationParams = (data: any) => {
   const keys: (keyof TodoCreationParams)[] = [
+    'id',
+
     'title',
     'description',
 

--- a/src/todos/todosController.ts
+++ b/src/todos/todosController.ts
@@ -12,7 +12,6 @@ import {
   Delete,
   Patch,
   Tags,
-  Query,
   Put,
 } from 'tsoa';
 import { TodoValidationParams } from './todo';

--- a/src/todos/todosService.ts
+++ b/src/todos/todosService.ts
@@ -81,8 +81,12 @@ export class TodosService {
 
   public async sync(user: User, todoId: string, params: TodoValidationParams) {
     const todoCreationParams = extractTodoCreationParams(params);
+
+    if (!todoCreationParams.id) {
+      todoCreationParams.id = todoId;
+    }
+
     const [todo] = await Todo.upsert({
-      id: todoId,
       userId: user.id,
       ...todoCreationParams,
     });


### PR DESCRIPTION
### 개요 (MOZI-356)

- `POST todos/`에서 `id`를 사용하지 않고 자체적으로 생성하는 오류를 고쳤습니다.
