### PR TITLE
feat: 새로운 google calendar todo는 밑에서부터 추가

### DIFF
--- a/src/migrations/migration.ts
+++ b/src/migrations/migration.ts
@@ -1,7 +1,6 @@
 import { User } from '@/users/user';
 import { TodoCreationParams } from '@/todos/todo';
 import { TodosService } from '@/todos/todosService';
-import sequelize from 'sequelize';
 
 export abstract class Migration {
   private user: User;

--- a/src/migrations/migration.ts
+++ b/src/migrations/migration.ts
@@ -1,6 +1,7 @@
 import { User } from '@/users/user';
 import { TodoCreationParams } from '@/todos/todo';
 import { TodosService } from '@/todos/todosService';
+import sequelize from 'sequelize';
 
 export abstract class Migration {
   private user: User;
@@ -25,8 +26,18 @@ export abstract class Migration {
   abstract parse(data: any[]): TodoCreationParams[];
 
   async push(todos: TodoCreationParams[]) {
+    let lastIndex =
+      (await this.user.getTodos()).reduce(
+        (previousValue, currentValue) => Math.max(previousValue, currentValue.index),
+        0,
+      ) + 1;
+
     for (const todo of todos) {
+      todo.index = lastIndex;
+
       await new TodosService().create(this.user, todo);
+
+      lastIndex++;
     }
   }
 }


### PR DESCRIPTION
### 개요

- 모든 `migration` 과정에서 새로 가져온 `Todo`의 `index` 는 최댓값으로 순서대로 넣어줍니다.
