### PR TITLE
feat: 추천 장소 검색 API

### DIFF
--- a/src/location/locationController.ts
+++ b/src/location/locationController.ts
@@ -9,11 +9,21 @@ export class LocationController extends Controller {
    * @param longitude 사용자 위치 경도
    * @param latitude 사용자 위치 위도
    * @param keyword 검색할 키워드
+   * @param recommended 추천 장소만 가져올건지 여부
    * @summary 위치와 키워드를 기반으로 장소를 반환합니다.
    */
   @SuccessResponse('200', 'Ok')
   @Get()
-  public async search(@Query() longitude: number, @Query() latitude: number, @Query() keyword: string) {
-    return new LocationService().search(longitude, latitude, keyword);
+  public async search(
+    @Query() longitude: number,
+    @Query() latitude: number,
+    @Query() keyword = '',
+    @Query() recommended?: boolean,
+  ) {
+    if (recommended) {
+      return new LocationService().recommend(longitude, latitude);
+    } else {
+      return new LocationService().search(longitude, latitude, keyword);
+    }
   }
 }

--- a/src/location/locationService.ts
+++ b/src/location/locationService.ts
@@ -2,12 +2,16 @@ import axios from 'axios';
 import { location } from './location';
 
 export class LocationService {
-  public async search(longitude: number, latitude: number, keyword: string) {
+  async search(longitude: number, latitude: number, keyword: string) {
     try {
       return await new NaverInstantSearch().search(longitude, latitude, keyword);
     } catch (error: unknown) {
       return await new GoogleNearBySearch().search(longitude, latitude, keyword);
     }
+  }
+
+  async recommend(longitude: number, latitude: number) {
+    return await new NaverRecommended().search(longitude, latitude, '가볼만한 곳');
   }
 }
 
@@ -81,7 +85,7 @@ class GoogleNearBySearch extends LocationSearch {
   protected parse(data: any): location[] {
     const { results } = data;
 
-    const locations: location[] = results((data: any) => {
+    const locations: location[] = results.map((data: any) => {
       const {
         name,
         geometry: {
@@ -92,6 +96,42 @@ class GoogleNearBySearch extends LocationSearch {
       const location: location = {
         name,
         location: [longitude, latitude],
+      };
+
+      return location;
+    });
+
+    return locations;
+  }
+}
+
+class NaverRecommended extends LocationSearch {
+  protected url = 'https://map.naver.com/v5/api/search';
+  protected apiKey: string | undefined;
+
+  protected async request(longitude: number, latitude: number, keyword: string): Promise<any> {
+    const { data } = await axios.get(this.url, {
+      params: {
+        query: keyword,
+        searchCoord: `${longitude};${latitude}`,
+        isPlaceRecommendationReplace: true,
+      },
+    });
+
+    return data;
+  }
+
+  protected parse(data: any): location[] {
+    const {
+      result: {
+        place: { list },
+      },
+    } = data;
+
+    const locations: location[] = list.map((data: any) => {
+      const location: location = {
+        name: data.name,
+        location: [parseFloat(data.x), parseFloat(data.y)],
       };
 
       return location;

--- a/tests/location/location.test.ts
+++ b/tests/location/location.test.ts
@@ -11,13 +11,14 @@ beforeAll(async () => {
   await loader(app);
 });
 
-const search = async (longitude: number, latitude: number, keyword: string) => {
+const search = async (url: string, longitude: number, latitude: number, keyword: string, recommended = false) => {
   return await request(app)
-    .get(`/api/v1/location/`)
+    .get(url)
     .query({
       longitude,
       latitude,
       keyword,
+      recommended,
     })
     .expect(200);
 };
@@ -25,7 +26,18 @@ const search = async (longitude: number, latitude: number, keyword: string) => {
 describe('InstantSearch', () => {
   test('Random search', async () => {
     const { longitude, latitude, keyword } = new Query();
-    const { body: locations } = await search(longitude, latitude, keyword);
+    const { body: locations } = await search(`/api/v1/location/`, longitude, latitude, keyword);
+
+    for (const location of locations) {
+      expect(validator(location)).toBeTruthy();
+    }
+  });
+});
+
+describe('Recommended location', () => {
+  test('Random search', async () => {
+    const { longitude, latitude, keyword } = new Query();
+    const { body: locations } = await search(`/api/v1/location/`, longitude, latitude, keyword, true);
 
     for (const location of locations) {
       expect(validator(location)).toBeTruthy();


### PR DESCRIPTION
### 개요

- `.../docs` 에서 `api/v1/location/`을 보면 모든 것을 확인할 수 있습니다.
  
![image](https://user-images.githubusercontent.com/44183313/202389070-707e7208-0fd5-4ed4-9316-2164727d6bbd.png)

  기존 장소 검색 API에서 `recommended=true`로 설정해주면 됩니다.

### 작업 사항

- 네이버 가볼만한 곳 API를 활용해서 주어진 지점 근처의 가볼만한 장소들만 검색할 수 있는 기능 추가
- 테스트 코드