### PR TITLE
feat: alarmType, distanceType 추가

### DIFF
--- a/src/todos/todo.ts
+++ b/src/todos/todo.ts
@@ -31,6 +31,9 @@ export class Todo extends Model<InferAttributes<Todo>, InferCreationAttributes<T
   declare longitude: CreationOptional<number>;
   declare latitude: CreationOptional<number>;
 
+  declare alarmType: CreationOptional<string>;
+  declare distanceType: CreationOptional<string>;
+
   declare index: CreationOptional<number>;
 }
 
@@ -62,6 +65,9 @@ export const define = (sequelize: Sequelize) => {
       longitude: DataTypes.FLOAT,
       latitude: DataTypes.FLOAT,
 
+      alarmType: DataTypes.STRING,
+      distanceType: DataTypes.STRING,
+
       index: DataTypes.INTEGER,
     },
     {
@@ -88,6 +94,9 @@ export interface TodoValidationParams {
   longitude?: number | null;
   latitude?: number | null;
 
+  alarmType?: string | null;
+  distanceType?: string | null;
+
   index?: number | null;
 }
 
@@ -106,6 +115,9 @@ export interface TodoCreationParams {
   locationName?: string;
   longitude?: number;
   latitude?: number;
+
+  alarmType?: string;
+  distanceType?: string;
 
   index?: number;
 }
@@ -126,6 +138,9 @@ export const extractTodoCreationParams = (data: any) => {
     'locationName',
     'longitude',
     'latitude',
+
+    'alarmType',
+    'distanceType',
 
     'index',
   ];

--- a/tests/todos/todos.test.ts
+++ b/tests/todos/todos.test.ts
@@ -6,7 +6,6 @@ import { getToken, MockUserCreateParams } from '../users/user';
 import { MockTodoCreationParams, removeAllTodos, request, createTodo, MockTodoUpdateParams } from './todo';
 import { User } from '../../src/users/user';
 import { Todo } from '../../src/todos/todo';
-import { faker } from '@faker-js/faker';
 import { TodoCreationParams } from '../../src/todos/todo';
 
 let app: Application;


### PR DESCRIPTION
### 세 줄 요약

- MySQL `todos` 테이블에 `alarmType`, `distanceType` 컬럼을 추가했습니다.
- `ENUM`으로 하려고했는데 [MySQL의 ENUM 타입을 사용하지 말아야 할 8가지 이유](https://velog.io/@leejh3224/%EB%B2%88%EC%97%AD-MySQL%EC%9D%98-ENUM-%ED%83%80%EC%9E%85%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%98%EC%A7%80-%EB%A7%90%EC%95%84%EC%95%BC-%ED%95%A0-8%EA%B0%80%EC%A7%80-%EC%9D%B4%EC%9C%A0)에서 확장성을 고려해서 절대로 `ENUM` 타입으로 선언하지 말라고해서 `string`으로 정의했습니다.
- 서버 `MySQL`에 마이그레이션 수동으로 진행했습니다. 로컬에서 테스트하시려면 MySQL에서 `mozi` 테이블에 접속하신 후에 이제
  ```mysql
  ALTER TABLE todos ADD alarmType VARCHAR(50);
  ALTER TABLE todos ADD distanceType VARCHAR(50);
  ```
   를 입력해주세요. 번거롭게 해드려서 죄송합니다...
